### PR TITLE
Fix for highlightSelectedMenuItem() to avoid sub/domain issues

### DIFF
--- a/htdocs/js/mellivora.js
+++ b/htdocs/js/mellivora.js
@@ -26,7 +26,7 @@ function showPageLoadModalDialogs() {
 
 function highlightSelectedMenuItem() {
     var path = window.location.pathname;
-    var activeMenuItems = document.querySelectorAll('.nav a[href*="' + path + '"]');
+    var activeMenuItems = document.querySelectorAll('.nav a[href$="' + path + '"]');
 
     for (var i = 0; i < activeMenuItems.length; i++) {
         if (activeMenuItems[i] && activeMenuItems[i].parentNode) {


### PR DESCRIPTION
If the ctf URL contains any "menu word" (home, challenges, hints, scores, profile..), it will cause a wrong behaviour highlighting the menu.

e.g. "**home**.myctf.com" or "www.leet-**challenges**.net"

Using the `[attribute$=value] ` JQuery selector fixes the issue.