### PR TITLE
Fix two bugs relating to non-competitors

### DIFF
--- a/include/layout/scores.inc.php
+++ b/include/layout/scores.inc.php
@@ -84,7 +84,8 @@ function challenges($categories) {
                 'submissions',
                 array(
                     'correct' => 1,
-                    'challenge' => $challenge['id']
+                    'challenge' => $challenge['id'],
+                    '(NOT (SELECT COUNT(*) FROM users WHERE id=user_id AND competing))' => 0
                 )
             );
 

--- a/include/layout/user.inc.php
+++ b/include/layout/user.inc.php
@@ -44,7 +44,7 @@ function print_solved_challenges($user_id) {
     $submissions = db_query_fetch_all('
         SELECT
            s.added,
-           ((SELECT COUNT(*) FROM submissions AS ss WHERE ss.correct = 1 AND ss.added < s.added AND ss.challenge=s.challenge)+1) AS pos,
+           ((SELECT COUNT(*) FROM submissions AS ss WHERE ss.correct = 1 AND ss.added < s.added AND ss.challenge=s.challenge AND (SELECT COUNT(*) FROM users WHERE id=ss.user_id AND competing))+1) AS pos,
            ch.id AS challenge_id,
            ch.available_from,
            ch.title,


### PR DESCRIPTION
Fix the two following bugs:
1. If a non-competitor solved a challenge before a competitor did, the competitor's profile page will list them as 2nd to solve the challenge even when they're the first competitor to do so. The scoreboard displays the first solver correctly. Here's me registering a non-competitor account, solving a challenge, registering a competitor account and solve the same challenge:
![image](https://user-images.githubusercontent.com/5837628/71784514-2716b700-2fa9-11ea-92d0-85da17f0fb59.png)

2. If a non-competitor solved a challenge, the scores page will include them when calculating the "solved by" percentage, as shown below:
![image](https://user-images.githubusercontent.com/5837628/71784485-d4d59600-2fa8-11ea-9706-13d34ac2d232.png)
