### PR TITLE
Update LAMP install readme to include unzip

### DIFF
--- a/install/lamp/README.md
+++ b/install/lamp/README.md
@@ -25,6 +25,11 @@ Install required PHP extensions
 sudo apt-get install php-curl php-pear php-mbstring
 ```
 
+Install Unzip (Required for Composer)
+```sh
+sudo apt-get install -y unzip
+```
+
 Install Composer
 ```sh
 curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
`unzip` tends to be installed on most machines quickly but is not installed by *default* on azure or AWS as of testing today. Added an instruction to install it to the README for LAMP installation.