### PR TITLE
Remove prestissimo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY install/lamp/mellivora.apache.conf /etc/apache2/sites-available/000-default
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
-RUN composer global require hirak/prestissimo
 WORKDIR /var/www/mellivora/
 RUN composer install --no-dev --optimize-autoloader
 


### PR DESCRIPTION
The latest composer version seems to be 2.0.2, and prestissimo refuses to install:
```
  [InvalidArgumentException]                                                                                                           
  Package hirak/prestissimo at version  has a PHP requirement incompatible with your PHP version, PHP extensions and Composer version  
```
Digging a bit deeper, it seems to only be used to parallelize composer downloads, which is already done in composer 2 (more details at https://github.com/hirak/prestissimo/issues/233)
I think it's a good idea to remove it. Mellivora builds perfectly fine with it removed and seems to be functional.